### PR TITLE
Keep lockfile updated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,14 @@ before_install:
   - export PATH=$HOME/.yarn/bin:$PATH
   - yarn global add phantomjs-prebuilt
   - phantomjs --version
+  - yarn global add greenkeeper-lockfile@1
 
 install:
-  - yarn install --frozen-lockfile
+  - yarn install
 
 script:
   # Usually, it's ok to finish the test scenario without reverting
   #  to the addon's original dependency state, skipping "cleanup".
   - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO test --skip-cleanup
+
+after_script: greenkeeper-lockfile-upload


### PR DESCRIPTION
Adding greenkeeper-lockfile package ensures that our yarn.lock file gets
updated whenever greenkeeper updates a dependency.